### PR TITLE
remove report breach

### DIFF
--- a/src/governor.cairo
+++ b/src/governor.cairo
@@ -52,11 +52,6 @@ pub trait IGovernor<TContractState> {
     // Cancel the proposal with the given ID. Only callable by the proposer.
     fn cancel(ref self: TContractState, id: felt252);
 
-    // Report a breach in the proposer's voting weight below the proposal creation threshold, canceling the proposal.
-    // The breach timestamp must be between when the proposal was created and the end of the voting period for the proposal.
-    // This method can be called by anyone at any time before the proposal is executed.
-    fn report_breach(ref self: TContractState, id: felt252, breach_timestamp: u64);
-
     // Execute the given proposal.
     fn execute(ref self: TContractState, id: felt252, calls: Span<Call>) -> Span<Span<felt252>>;
 
@@ -143,12 +138,6 @@ pub mod Governor {
         pub id: felt252,
     }
 
-    #[derive(starknet::Event, Drop)]
-    pub struct CreationThresholdBreached {
-        pub id: felt252,
-        pub breach_timestamp: u64,
-    }
-
     #[derive(starknet::Event, Drop, PartialEq, Debug)]
     pub struct Executed {
         pub id: felt252,
@@ -168,7 +157,6 @@ pub mod Governor {
         Described: Described,
         Voted: Voted,
         Canceled: Canceled,
-        CreationThresholdBreached: CreationThresholdBreached,
         Executed: Executed,
         Reconfigured: Reconfigured,
     }
@@ -356,50 +344,6 @@ pub mod Governor {
             self.proposals.write(id, proposal);
 
             self.emit(Canceled { id });
-        }
-
-        fn report_breach(ref self: ContractState, id: felt252, breach_timestamp: u64) {
-            let (mut proposal, config) = self.get_proposal_with_config(id);
-
-            assert(proposal.proposer.is_non_zero(), 'DOES_NOT_EXIST');
-
-            assert(proposal.execution_state.canceled.is_zero(), 'ALREADY_CANCELED');
-            assert(proposal.execution_state.executed.is_zero(), 'ALREADY_EXECUTED');
-            assert(breach_timestamp >= proposal.execution_state.created, 'PROPOSAL_NOT_CREATED');
-
-            assert(
-                breach_timestamp < (proposal.execution_state.created
-                    + config.voting_start_delay
-                    + config.voting_period),
-                'VOTING_ENDED'
-            );
-
-            // check that at the given timestamp, during the voting period and after the proposal was created, the proposer's delegation
-            // fell below the proposal creation threshold
-            assert(
-                self
-                    .get_staker()
-                    .get_average_delegated(
-                        delegate: proposal.proposer,
-                        start: breach_timestamp - config.voting_weight_smoothing_duration,
-                        end: breach_timestamp
-                    ) < config
-                    .proposal_creation_threshold,
-                'THRESHOLD_NOT_BREACHED'
-            );
-
-            proposal
-                .execution_state =
-                    ExecutionState {
-                        created: proposal.execution_state.created,
-                        // we asserted that it is not already executed
-                        executed: 0,
-                        canceled: get_block_timestamp()
-                    };
-
-            self.proposals.write(id, proposal);
-
-            self.emit(CreationThresholdBreached { id, breach_timestamp });
         }
 
         fn execute(

--- a/src/governor_test.cairo
+++ b/src/governor_test.cairo
@@ -571,54 +571,6 @@ fn test_cancel_by_non_proposer() {
 }
 
 #[test]
-fn test_report_breach_by_non_proposer() {
-    let (staker, token, governor, config) = setup();
-
-    let id = create_proposal(governor, token, staker);
-    staker.withdraw_amount(proposer(), recipient: Zero::zero(), amount: 25);
-
-    // Fast forward one smoothing duration
-    advance_time(config.voting_weight_smoothing_duration);
-
-    // A random user can now cancel the proposal
-    set_contract_address(anyone());
-    governor.report_breach(id, get_block_timestamp());
-
-    // Expect that proposal is no longer available
-    let proposal = governor.get_proposal(id);
-    assert_eq!(
-        proposal,
-        ProposalInfo {
-            calls_hash: hash_calls(
-                @array![transfer_call(token: token, recipient: recipient(), amount: 100)].span()
-            ),
-            proposer: proposer(),
-            execution_state: ExecutionState {
-                created: config.voting_weight_smoothing_duration,
-                executed: 0,
-                canceled: config.voting_weight_smoothing_duration * 2
-            },
-            yea: 0,
-            nay: 0,
-            config_version: 0,
-        }
-    );
-}
-
-#[test]
-#[should_panic(expected: ('THRESHOLD_NOT_BREACHED', 'ENTRYPOINT_FAILED'))]
-fn test_cancel_by_non_proposer_threshold_not_breached_should_fail() {
-    let (staker, token, governor, _config) = setup();
-
-    let id = create_proposal(governor, token, staker);
-
-    // A random user can't now cancel the proposal because
-    // the proposer's voting power is still above threshold
-    set_contract_address(anyone());
-    governor.report_breach(id, get_block_timestamp());
-}
-
-#[test]
 #[should_panic(expected: ('VOTING_STARTED', 'ENTRYPOINT_FAILED'))]
 fn test_cancel_after_voting_end_should_fail() {
     let (staker, token, governor, config) = setup();


### PR DESCRIPTION
The purpose of this method is unclear

In addition, it can be used to cancel a proposal after voting has started. E.g. delegate to new account, create proposal from new account, wait for everyone to vote, then undelegate and report breach on the proposal

Instead, users of these contracts should consider increasing voting delay, which allows more time for cancellation and undelegating to the proposer if it is undesirable