### PR TITLE
Fix active proposal gate config version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.5.1
 
       - name: Show Forge version
         run: |

--- a/l1_proxy/src/StarknetOwnerProxy.sol
+++ b/l1_proxy/src/StarknetOwnerProxy.sol
@@ -46,10 +46,7 @@ contract StarknetOwnerProxy {
         return payload;
     }
 
-    function execute(address target, uint256 value, uint64 nonce, bytes calldata data)
-        external
-        returns (bytes memory)
-    {
+    function execute(address target, uint256 value, uint64 nonce, bytes calldata data) external returns (bytes memory) {
         if (target == address(0) || target == address(this)) {
             revert InvalidTarget();
         }

--- a/src/governor.cairo
+++ b/src/governor.cairo
@@ -221,15 +221,17 @@ pub mod Governor {
 
             let latest_proposal_id = self.latest_proposal_by_proposer.read(proposer);
             if latest_proposal_id.is_non_zero() {
-                let latest_proposal_state = self.get_proposal(latest_proposal_id).execution_state;
+                let (latest_proposal, latest_proposal_config) = self
+                    .get_proposal_with_config(latest_proposal_id);
+                let latest_proposal_state = latest_proposal.execution_state;
 
                 // if the proposal is not canceled, check that the voting for that proposal has
                 // ended
                 if latest_proposal_state.canceled.is_zero() {
                     assert(
                         latest_proposal_state.created
-                            + config.voting_start_delay
-                            + config.voting_period <= timestamp_current,
+                            + latest_proposal_config.voting_start_delay
+                            + latest_proposal_config.voting_period <= timestamp_current,
                         'PROPOSER_HAS_ACTIVE_PROPOSAL',
                     );
                 }

--- a/src/governor_test.cairo
+++ b/src/governor_test.cairo
@@ -208,6 +208,37 @@ fn test_proposer_can_wait_out_original_proposal_and_re_propose() {
 }
 
 #[test]
+#[should_panic(expected: ('PROPOSER_HAS_ACTIVE_PROPOSAL', 'ENTRYPOINT_FAILED'))]
+fn test_propose_active_proposal_gate_uses_latest_proposal_config_version() {
+    let (staker, token, governor, config) = setup();
+
+    token.approve(staker.contract_address, config.proposal_creation_threshold.into());
+    staker.stake(proposer());
+    advance_time(config.voting_weight_smoothing_duration);
+
+    set_contract_address(proposer());
+    governor.propose(array![transfer_call(token, recipient(), amount: 100)].span());
+
+    let new_config = Config {
+        voting_start_delay: 1,
+        voting_period: 2,
+        voting_weight_smoothing_duration: config.voting_weight_smoothing_duration,
+        quorum: config.quorum,
+        proposal_creation_threshold: config.proposal_creation_threshold,
+        execution_delay: config.execution_delay,
+        execution_window: config.execution_window,
+    };
+
+    set_contract_address(governor.contract_address);
+    governor.reconfigure(new_config);
+
+    advance_time(new_config.voting_start_delay + new_config.voting_period);
+
+    set_contract_address(proposer());
+    governor.propose(array![transfer_call(token, recipient(), amount: 101)].span());
+}
+
+#[test]
 fn test_proposer_can_cancel_and_propose_different() {
     let (staker, token, governor, config) = setup();
 


### PR DESCRIPTION
## Summary
- use the previous proposal's pinned config when enforcing the per-proposer active-proposal gate
- add a regression test for shortening proposal timing via reconfiguration while an older proposal is still active under its own config
- pin CI Foundry from nightly to v1.5.1, matching the local 1.5.x toolchain line
- format the existing Starknet owner proxy line required by Foundry v1.5.1 so CI fmt can pass

## Verification
- scarb test
- forge fmt --check
- forge test
- git diff --check

## Notes
- Confirmed the regression test fails before the governor fix and passes after it.
- Repository-wide `scarb fmt --check` has unrelated pre-existing Cairo formatting drift.