### PR TITLE
Fix Arbitrum owner handover aliasing

### DIFF
--- a/l1_proxy/src/ArbitrumOwnerProxy.sol
+++ b/l1_proxy/src/ArbitrumOwnerProxy.sol
@@ -20,6 +20,8 @@ library ArbitrumAddressAliasHelper {
 }
 
 contract ArbitrumOwnerProxy is Ownable {
+    uint256 private constant _HANDOVER_SLOT_SEED = 0x389a75e1;
+
     error InvalidTarget();
     error InsufficientBalance();
     error RenounceOwnershipDisabled();
@@ -45,6 +47,19 @@ contract ArbitrumOwnerProxy is Ownable {
 
     function renounceOwnership() public payable override onlyOwner {
         revert RenounceOwnershipDisabled();
+    }
+
+    function completeOwnershipHandover(address pendingOwner) public payable override onlyOwner {
+        uint256 expires = ownershipHandoverExpiresAt(pendingOwner);
+        if (expires == 0 || block.timestamp > expires) revert NoHandoverRequest();
+
+        assembly {
+            mstore(0x0c, _HANDOVER_SLOT_SEED)
+            mstore(0x00, pendingOwner)
+            sstore(keccak256(0x0c, 0x20), 0)
+        }
+
+        _setOwner(ArbitrumAddressAliasHelper.undoL1ToL2Alias(pendingOwner));
     }
 
     function _checkOwner() internal view override {

--- a/l1_proxy/test/ArbitrumOwnerProxy.t.sol
+++ b/l1_proxy/test/ArbitrumOwnerProxy.t.sol
@@ -133,6 +133,29 @@ contract ArbitrumOwnerProxyTest is Test {
         proxy.transferOwnership(address(0));
     }
 
+    function test_complete_ownership_handover_stores_unaliased_l1_owner() public {
+        address oldAlias = proxy.l2OwnerAlias();
+        address newAlias = ArbitrumAddressAliasHelper.applyL1ToL2Alias(OTHER_L1_OWNER);
+
+        vm.prank(newAlias);
+        proxy.requestOwnershipHandover();
+
+        vm.prank(oldAlias);
+        proxy.completeOwnershipHandover(newAlias);
+
+        assertEq(proxy.owner(), OTHER_L1_OWNER);
+        assertEq(proxy.l2OwnerAlias(), newAlias);
+        assertEq(proxy.ownershipHandoverExpiresAt(newAlias), 0);
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        vm.prank(oldAlias);
+        proxy.execute(address(target), 0, abi.encodeWithSelector(ArbitrumTestTarget.setX.selector, 1));
+
+        vm.prank(newAlias);
+        proxy.execute(address(target), 0, abi.encodeWithSelector(ArbitrumTestTarget.setX.selector, 2));
+        assertEq(target.x(), 2);
+    }
+
     function test_renounce_ownership_disabled() public {
         address ownerAlias = proxy.l2OwnerAlias();
 


### PR DESCRIPTION
## Summary
- override ArbitrumOwnerProxy completeOwnershipHandover so completed handovers keep owner() as the unaliased L1 owner
- validate and clear the Solady handover slot for the aliased pending owner before storing the unaliased owner
- add regression coverage showing the new L1 owner's retryable alias can execute after handover and the old alias cannot

## Verification
- forge test
- forge test --match-contract ArbitrumOwnerProxyTest
- forge fmt --check src/ArbitrumOwnerProxy.sol test/ArbitrumOwnerProxy.t.sol
- git diff --check

## Notes
- The issue is necessary to fix: inherited Solady handover stores the raw L2 alias in owner(), which causes ArbitrumOwnerProxy to require a double-alias sender afterward.
- Repository-wide `forge fmt --check` still depends on the existing main formatting cleanup handled in PR #74.