### PR TITLE
Allow L1 and L2 owner execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Contracts in this repository are designed so that they may be used together _or_
 
 - Deploy it on the Arbitrum child chain with the unaliased L1 owner address
 - `owner()` returns the unaliased L1 owner address
-- L1-to-L2 retryable ticket calls are authorized when `msg.sender` is the owner's Arbitrum alias, exposed as `l2OwnerAlias()`
-- The L1 owner can call `execute(target, value, data)` to make arbitrary calls from the proxy
+- Owner-gated calls are authorized from either the raw owner address on L2 or the owner's Arbitrum alias from an L1-to-L2 retryable ticket, exposed as `l2OwnerAlias()`
+- The owner can call `execute(target, value, data)` from either path to make arbitrary calls from the proxy
 
 #### OPStackOwnerProxy.sol: OP Stack / Base L2 Proxy
 
@@ -70,8 +70,8 @@ Contracts in this repository are designed so that they may be used together _or_
 
 - Deploy it on the child chain with the L1 owner address
 - `owner()` returns the L1 owner address
-- L1-to-L2 calls are authorized only when `msg.sender` is the `L2CrossDomainMessenger` predeploy at `0x4200000000000000000000000000000000000007` and `xDomainMessageSender()` is the L1 owner
-- The L1 owner can call `execute(target, value, data)` through that chain's `L1CrossDomainMessenger` to make arbitrary calls from the proxy
+- Owner-gated calls are authorized from either the raw owner address on L2 or an L1-to-L2 message where `msg.sender` is the `L2CrossDomainMessenger` predeploy at `0x4200000000000000000000000000000000000007` and `xDomainMessageSender()` is the L1 owner
+- The owner can call `execute(target, value, data)` from either path to make arbitrary calls from the proxy
 
 ## Testing
 

--- a/l1_proxy/src/ArbitrumOwnerProxy.sol
+++ b/l1_proxy/src/ArbitrumOwnerProxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.28;
 
-import {Ownable} from "solady/auth/Ownable.sol";
+import {L1L2OwnerProxy} from "./L1L2OwnerProxy.sol";
 
 library ArbitrumAddressAliasHelper {
     uint160 internal constant OFFSET = uint160(0x1111000000000000000000000000000000001111);
@@ -19,36 +19,15 @@ library ArbitrumAddressAliasHelper {
     }
 }
 
-contract ArbitrumOwnerProxy is Ownable {
-    error InvalidTarget();
-    error InsufficientBalance();
-    error RenounceOwnershipDisabled();
-    error CallFailed(bytes data);
-
-    constructor(address initialOwner) {
-        if (initialOwner == address(0)) revert NewOwnerIsZeroAddress();
-        _initializeOwner(initialOwner);
-    }
+contract ArbitrumOwnerProxy is L1L2OwnerProxy {
+    constructor(address initialOwner) L1L2OwnerProxy(initialOwner) {}
 
     function l2OwnerAlias() public view returns (address) {
         return ArbitrumAddressAliasHelper.applyL1ToL2Alias(owner());
     }
 
-    function execute(address target, uint256 value, bytes calldata data) external onlyOwner returns (bytes memory) {
-        if (target == address(0)) revert InvalidTarget();
-        if (address(this).balance < value) revert InsufficientBalance();
-
-        (bool success, bytes memory result) = target.call{value: value}(data);
-        if (!success) revert CallFailed(result);
-        return result;
-    }
-
-    function renounceOwnership() public payable override onlyOwner {
-        revert RenounceOwnershipDisabled();
-    }
-
-    function _checkOwner() internal view override {
-        if (msg.sender != l2OwnerAlias()) revert Unauthorized();
+    function _isL1Owner() internal view override returns (bool) {
+        return msg.sender == l2OwnerAlias();
     }
 
     receive() external payable {}

--- a/l1_proxy/src/L1L2OwnerProxy.sol
+++ b/l1_proxy/src/L1L2OwnerProxy.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.28;
+
+import {Ownable} from "solady/auth/Ownable.sol";
+
+abstract contract L1L2OwnerProxy is Ownable {
+    error InvalidTarget();
+    error InsufficientBalance();
+    error CallFailed(bytes data);
+
+    constructor(address initialOwner) {
+        if (initialOwner == address(0)) revert NewOwnerIsZeroAddress();
+        _initializeOwner(initialOwner);
+    }
+
+    function execute(address target, uint256 value, bytes calldata data) external onlyOwner returns (bytes memory) {
+        if (target == address(0)) revert InvalidTarget();
+        if (address(this).balance < value) revert InsufficientBalance();
+
+        (bool success, bytes memory result) = target.call{value: value}(data);
+        if (!success) revert CallFailed(result);
+        return result;
+    }
+
+    function _checkOwner() internal view override {
+        if (msg.sender != owner() && !_isL1Owner()) revert Unauthorized();
+    }
+
+    function _isL1Owner() internal view virtual returns (bool);
+}

--- a/l1_proxy/src/OPStackOwnerProxy.sol
+++ b/l1_proxy/src/OPStackOwnerProxy.sol
@@ -1,45 +1,20 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.28;
 
-import {Ownable} from "solady/auth/Ownable.sol";
+import {L1L2OwnerProxy} from "./L1L2OwnerProxy.sol";
 
 interface ICrossDomainMessenger {
     function xDomainMessageSender() external view returns (address);
 }
 
-contract OPStackOwnerProxy is Ownable {
+contract OPStackOwnerProxy is L1L2OwnerProxy {
     address public constant L2_CROSS_DOMAIN_MESSENGER = 0x4200000000000000000000000000000000000007;
 
-    error InvalidTarget();
-    error InsufficientBalance();
-    error RenounceOwnershipDisabled();
-    error CallFailed(bytes data);
+    constructor(address initialOwner) L1L2OwnerProxy(initialOwner) {}
 
-    constructor(address initialOwner) {
-        if (initialOwner == address(0)) revert NewOwnerIsZeroAddress();
-        _initializeOwner(initialOwner);
-    }
-
-    function execute(address target, uint256 value, bytes calldata data) external onlyOwner returns (bytes memory) {
-        if (target == address(0)) revert InvalidTarget();
-        if (address(this).balance < value) revert InsufficientBalance();
-
-        (bool success, bytes memory result) = target.call{value: value}(data);
-        if (!success) revert CallFailed(result);
-        return result;
-    }
-
-    function renounceOwnership() public payable override onlyOwner {
-        revert RenounceOwnershipDisabled();
-    }
-
-    function _checkOwner() internal view override {
-        if (
-            msg.sender != L2_CROSS_DOMAIN_MESSENGER
-                || ICrossDomainMessenger(L2_CROSS_DOMAIN_MESSENGER).xDomainMessageSender() != owner()
-        ) {
-            revert Unauthorized();
-        }
+    function _isL1Owner() internal view override returns (bool) {
+        return msg.sender == L2_CROSS_DOMAIN_MESSENGER
+            && ICrossDomainMessenger(L2_CROSS_DOMAIN_MESSENGER).xDomainMessageSender() == owner();
     }
 
     receive() external payable {}

--- a/l1_proxy/test/ArbitrumOwnerProxy.t.sol
+++ b/l1_proxy/test/ArbitrumOwnerProxy.t.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {ArbitrumAddressAliasHelper, ArbitrumOwnerProxy} from "../src/ArbitrumOwnerProxy.sol";
+import {L1L2OwnerProxy} from "../src/L1L2OwnerProxy.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
 
 contract ArbitrumTestTarget {
@@ -44,8 +45,8 @@ contract ArbitrumOwnerProxyTest is Test {
         new ArbitrumOwnerProxy(address(0));
     }
 
-    function test_execute_from_l1_owner_alias() public {
-        vm.prank(proxy.l2OwnerAlias());
+    function test_execute_from_l2_owner() public {
+        vm.prank(L1_OWNER);
         bytes memory result =
             proxy.execute(address(target), 0, abi.encodeWithSelector(ArbitrumTestTarget.setX.selector, 123));
 
@@ -56,7 +57,7 @@ contract ArbitrumOwnerProxyTest is Test {
     function test_execute_forwards_value() public {
         vm.deal(address(proxy), 1 ether);
 
-        vm.prank(proxy.l2OwnerAlias());
+        vm.prank(L1_OWNER);
         proxy.execute(address(target), 0.25 ether, abi.encodeWithSelector(ArbitrumTestTarget.setX.selector, 5));
 
         assertEq(target.x(), 5);
@@ -64,10 +65,11 @@ contract ArbitrumOwnerProxyTest is Test {
         assertEq(address(proxy).balance, 0.75 ether);
     }
 
-    function test_execute_reverts_from_l1_owner_without_alias() public {
-        vm.expectRevert(Ownable.Unauthorized.selector);
-        vm.prank(L1_OWNER);
+    function test_execute_accepts_l1_owner_alias() public {
+        vm.prank(proxy.l2OwnerAlias());
         proxy.execute(address(target), 0, abi.encodeWithSelector(ArbitrumTestTarget.setX.selector, 123));
+
+        assertEq(target.x(), 123);
     }
 
     function test_execute_reverts_from_random_address() public {
@@ -79,35 +81,45 @@ contract ArbitrumOwnerProxyTest is Test {
     }
 
     function test_execute_reverts_invalid_target() public {
-        address ownerAlias = proxy.l2OwnerAlias();
-
-        vm.expectRevert(ArbitrumOwnerProxy.InvalidTarget.selector);
-        vm.prank(ownerAlias);
+        vm.expectRevert(L1L2OwnerProxy.InvalidTarget.selector);
+        vm.prank(L1_OWNER);
         proxy.execute(address(0), 0, "");
     }
 
     function test_execute_reverts_insufficient_balance() public {
-        address ownerAlias = proxy.l2OwnerAlias();
-
-        vm.expectRevert(ArbitrumOwnerProxy.InsufficientBalance.selector);
-        vm.prank(ownerAlias);
+        vm.expectRevert(L1L2OwnerProxy.InsufficientBalance.selector);
+        vm.prank(L1_OWNER);
         proxy.execute(address(target), 1, abi.encodeWithSelector(ArbitrumTestTarget.setX.selector, 123));
     }
 
     function test_execute_reverts_call_failure() public {
-        address ownerAlias = proxy.l2OwnerAlias();
-
         vm.expectRevert(
             abi.encodeWithSelector(
-                ArbitrumOwnerProxy.CallFailed.selector,
+                L1L2OwnerProxy.CallFailed.selector,
                 abi.encodeWithSelector(ArbitrumTestTarget.RandomError.selector, uint256(0))
             )
         );
-        vm.prank(ownerAlias);
+        vm.prank(L1_OWNER);
         proxy.execute(address(target), 0, abi.encodeWithSelector(ArbitrumTestTarget.reverts.selector));
     }
 
     function test_transfer_ownership_to_new_l1_owner() public {
+        vm.prank(L1_OWNER);
+        proxy.transferOwnership(OTHER_L1_OWNER);
+
+        assertEq(proxy.owner(), OTHER_L1_OWNER);
+        assertEq(proxy.l2OwnerAlias(), ArbitrumAddressAliasHelper.applyL1ToL2Alias(OTHER_L1_OWNER));
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        vm.prank(L1_OWNER);
+        proxy.execute(address(target), 0, abi.encodeWithSelector(ArbitrumTestTarget.setX.selector, 1));
+
+        vm.prank(OTHER_L1_OWNER);
+        proxy.execute(address(target), 0, abi.encodeWithSelector(ArbitrumTestTarget.setX.selector, 2));
+        assertEq(target.x(), 2);
+    }
+
+    function test_transfer_ownership_to_new_l1_owner_from_l1_alias() public {
         address oldAlias = proxy.l2OwnerAlias();
 
         vm.prank(oldAlias);
@@ -126,18 +138,22 @@ contract ArbitrumOwnerProxyTest is Test {
     }
 
     function test_transfer_ownership_reverts_zero_owner() public {
-        address ownerAlias = proxy.l2OwnerAlias();
-
         vm.expectRevert(Ownable.NewOwnerIsZeroAddress.selector);
-        vm.prank(ownerAlias);
+        vm.prank(L1_OWNER);
         proxy.transferOwnership(address(0));
     }
 
-    function test_renounce_ownership_disabled() public {
-        address ownerAlias = proxy.l2OwnerAlias();
-
-        vm.expectRevert(ArbitrumOwnerProxy.RenounceOwnershipDisabled.selector);
-        vm.prank(ownerAlias);
+    function test_renounce_ownership_from_l2_owner() public {
+        vm.prank(L1_OWNER);
         proxy.renounceOwnership();
+
+        assertEq(proxy.owner(), address(0));
+    }
+
+    function test_renounce_ownership_from_l1_alias() public {
+        vm.prank(proxy.l2OwnerAlias());
+        proxy.renounceOwnership();
+
+        assertEq(proxy.owner(), address(0));
     }
 }

--- a/l1_proxy/test/OPStackOwnerProxy.t.sol
+++ b/l1_proxy/test/OPStackOwnerProxy.t.sol
@@ -2,6 +2,7 @@
 pragma solidity =0.8.28;
 
 import {Test} from "forge-std/Test.sol";
+import {L1L2OwnerProxy} from "../src/L1L2OwnerProxy.sol";
 import {OPStackOwnerProxy} from "../src/OPStackOwnerProxy.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
 
@@ -55,10 +56,8 @@ contract OPStackOwnerProxyTest is Test {
         new OPStackOwnerProxy(address(0));
     }
 
-    function test_execute_from_l1_owner_through_l2_messenger() public {
-        _setXDomainMessageSender(L1_OWNER);
-
-        vm.prank(L2_CROSS_DOMAIN_MESSENGER);
+    function test_execute_from_l2_owner() public {
+        vm.prank(L1_OWNER);
         bytes memory result =
             proxy.execute(address(target), 0, abi.encodeWithSelector(OPStackTestTarget.setX.selector, 123));
 
@@ -68,9 +67,8 @@ contract OPStackOwnerProxyTest is Test {
 
     function test_execute_forwards_value() public {
         vm.deal(address(proxy), 1 ether);
-        _setXDomainMessageSender(L1_OWNER);
 
-        vm.prank(L2_CROSS_DOMAIN_MESSENGER);
+        vm.prank(L1_OWNER);
         proxy.execute(address(target), 0.25 ether, abi.encodeWithSelector(OPStackTestTarget.setX.selector, 5));
 
         assertEq(target.x(), 5);
@@ -78,12 +76,13 @@ contract OPStackOwnerProxyTest is Test {
         assertEq(address(proxy).balance, 0.75 ether);
     }
 
-    function test_execute_reverts_from_l1_owner_without_messenger() public {
+    function test_execute_accepts_l1_owner_through_l2_messenger() public {
         _setXDomainMessageSender(L1_OWNER);
 
-        vm.expectRevert(Ownable.Unauthorized.selector);
-        vm.prank(L1_OWNER);
+        vm.prank(L2_CROSS_DOMAIN_MESSENGER);
         proxy.execute(address(target), 0, abi.encodeWithSelector(OPStackTestTarget.setX.selector, 123));
+
+        assertEq(target.x(), 123);
     }
 
     function test_execute_reverts_from_messenger_with_wrong_l1_sender() public {
@@ -103,35 +102,44 @@ contract OPStackOwnerProxyTest is Test {
     }
 
     function test_execute_reverts_invalid_target() public {
-        _setXDomainMessageSender(L1_OWNER);
-
-        vm.expectRevert(OPStackOwnerProxy.InvalidTarget.selector);
-        vm.prank(L2_CROSS_DOMAIN_MESSENGER);
+        vm.expectRevert(L1L2OwnerProxy.InvalidTarget.selector);
+        vm.prank(L1_OWNER);
         proxy.execute(address(0), 0, "");
     }
 
     function test_execute_reverts_insufficient_balance() public {
-        _setXDomainMessageSender(L1_OWNER);
-
-        vm.expectRevert(OPStackOwnerProxy.InsufficientBalance.selector);
-        vm.prank(L2_CROSS_DOMAIN_MESSENGER);
+        vm.expectRevert(L1L2OwnerProxy.InsufficientBalance.selector);
+        vm.prank(L1_OWNER);
         proxy.execute(address(target), 1, abi.encodeWithSelector(OPStackTestTarget.setX.selector, 123));
     }
 
     function test_execute_reverts_call_failure() public {
-        _setXDomainMessageSender(L1_OWNER);
-
         vm.expectRevert(
             abi.encodeWithSelector(
-                OPStackOwnerProxy.CallFailed.selector,
+                L1L2OwnerProxy.CallFailed.selector,
                 abi.encodeWithSelector(OPStackTestTarget.RandomError.selector, uint256(0))
             )
         );
-        vm.prank(L2_CROSS_DOMAIN_MESSENGER);
+        vm.prank(L1_OWNER);
         proxy.execute(address(target), 0, abi.encodeWithSelector(OPStackTestTarget.reverts.selector));
     }
 
     function test_transfer_ownership_to_new_l1_owner() public {
+        vm.prank(L1_OWNER);
+        proxy.transferOwnership(OTHER_L1_OWNER);
+
+        assertEq(proxy.owner(), OTHER_L1_OWNER);
+
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        vm.prank(L1_OWNER);
+        proxy.execute(address(target), 0, abi.encodeWithSelector(OPStackTestTarget.setX.selector, 1));
+
+        vm.prank(OTHER_L1_OWNER);
+        proxy.execute(address(target), 0, abi.encodeWithSelector(OPStackTestTarget.setX.selector, 2));
+        assertEq(target.x(), 2);
+    }
+
+    function test_transfer_ownership_to_new_l1_owner_from_l1_messenger() public {
         _setXDomainMessageSender(L1_OWNER);
 
         vm.prank(L2_CROSS_DOMAIN_MESSENGER);
@@ -151,19 +159,25 @@ contract OPStackOwnerProxyTest is Test {
     }
 
     function test_transfer_ownership_reverts_zero_owner() public {
-        _setXDomainMessageSender(L1_OWNER);
-
         vm.expectRevert(Ownable.NewOwnerIsZeroAddress.selector);
-        vm.prank(L2_CROSS_DOMAIN_MESSENGER);
+        vm.prank(L1_OWNER);
         proxy.transferOwnership(address(0));
     }
 
-    function test_renounce_ownership_disabled() public {
+    function test_renounce_ownership_from_l2_owner() public {
+        vm.prank(L1_OWNER);
+        proxy.renounceOwnership();
+
+        assertEq(proxy.owner(), address(0));
+    }
+
+    function test_renounce_ownership_from_l1_messenger() public {
         _setXDomainMessageSender(L1_OWNER);
 
-        vm.expectRevert(OPStackOwnerProxy.RenounceOwnershipDisabled.selector);
         vm.prank(L2_CROSS_DOMAIN_MESSENGER);
         proxy.renounceOwnership();
+
+        assertEq(proxy.owner(), address(0));
     }
 
     function _setXDomainMessageSender(address sender) internal {


### PR DESCRIPTION
## Summary
- add a shared L1L2OwnerProxy base for Arbitrum and OP Stack owner proxies
- override Solady _checkOwner() so owner-gated functions accept either the raw owner address on L2 or the chain-specific authenticated L1 owner path
- keep a single execute(target, value, data) entrypoint while allowing inherited owner-gated functions, including transferOwnership and renounceOwnership, to work from L1 as well
- update Arbitrum and OP Stack tests/docs for both L1 and L2 owner execution paths

## Verification
- forge fmt --check
- forge test
- forge build --sizes
- git diff --check