### PR TITLE
Remove unsafe StakerV2 share getter

### DIFF
--- a/src/staker_v2.cairo
+++ b/src/staker_v2.cairo
@@ -71,15 +71,11 @@ pub trait IStakerV2<TContractState> {
     fn get_total_staked_at(self: @TContractState, timestamp: u64) -> u128;
 
     fn get_average_total_staked_over_period(self: @TContractState, start: u64, end: u64) -> u128;
-
-    fn get_user_share_of_total_staked_over_period(
-        self: @TContractState, staked: u128, start: u64, end: u64,
-    ) -> u128;
 }
 
 #[starknet::contract]
 pub mod Staker {
-    use core::num::traits::{OverflowingMul, zero::Zero};
+    use core::num::traits::zero::Zero;
     use governance::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use starknet::storage::{
         Map, MutableVecTrait, StorageMapReadAccess, StorageMapWriteAccess, StoragePathEntry,
@@ -460,21 +456,6 @@ pub mod Staker {
             let period_length = end - start;
 
             ((end_snapshot - start_snapshot) / period_length.into()).try_into().unwrap()
-        }
-
-        fn get_user_share_of_total_staked_over_period(
-            self: @ContractState, staked: u128, start: u64, end: u64,
-        ) -> u128 {
-            assert(end > start, 'ORDER');
-
-            let start_snapshot = self.get_seconds_per_total_staked_sum_at(start);
-            let end_snapshot = self.get_seconds_per_total_staked_sum_at(end);
-
-            let (weighted_stake_seconds, overflow) = (end_snapshot - start_snapshot)
-                .overflowing_mul(staked.into() * 100);
-            assert(!overflow, 'SHARE_OVERFLOW');
-
-            weighted_stake_seconds.high / (end - start).into()
         }
     }
 }

--- a/src/staker_v2_test.cairo
+++ b/src/staker_v2_test.cairo
@@ -407,36 +407,6 @@ mod staker_staked_seconds_per_total_staked_calculation {
     }
 
     #[test]
-    fn test_user_share_preserves_precision_for_short_period() {
-        let (staker, token) = setup(1024);
-        let delegatee = 1234567890.try_into().unwrap();
-
-        set_block_timestamp(10);
-        token.approve(staker.contract_address, 1024);
-        staker.stake(delegatee);
-
-        assert_eq!(staker.get_user_share_of_total_staked_over_period(0, 10, 11), 0);
-        assert_eq!(staker.get_user_share_of_total_staked_over_period(1024, 10, 11), 100);
-    }
-
-    #[test]
-    fn test_user_share_preserves_weight_across_stake_changes() {
-        let (staker, token) = setup(2048);
-        let delegatee = 1234567890.try_into().unwrap();
-
-        set_block_timestamp(10);
-        token.approve(staker.contract_address, 1024);
-        staker.stake(delegatee);
-
-        set_block_timestamp(11);
-        token.approve(staker.contract_address, 1024);
-        staker.stake(delegatee);
-
-        // 100% for the first second and 50% for the second second.
-        assert_eq!(staker.get_user_share_of_total_staked_over_period(1024, 10, 12), 75);
-    }
-
-    #[test]
     #[should_panic(expected: ('INSUFFICIENT_AMOUNT_STAKED', 'ENTRYPOINT_FAILED'))]
     fn test_raises_error_if_no_history_exists_and_withdrawal_happens() {
         // TODO(biatcode): This test accidentally tests other


### PR DESCRIPTION
## Summary

- remove `get_user_share_of_total_staked_over_period` from the `IStakerV2` interface and contract implementation
- remove the getter-specific tests added by #77
- eliminate the overflow-prone share calculation instead of exposing an unreliable result

## Compatibility

This intentionally removes a public ABI entrypoint from newly declared `StakerV2` classes. Repository-wide search found no callers. External integrations that call this selector must stop doing so before adopting the new class; already-deployed contract classes are unchanged. All other staking entrypoints and stored state remain unchanged.

## Validation

- `scarb build`
- `scarb test` (157 passed)
- repository-wide search confirms no remaining references to the removed getter

<!-- apex-fix-review:eyJ2IjoidjEiLCJoIjoiYWU2NjhhNWEtM2ZiNC00OGNlLWIwZjgtNDY1MzM1ZjRhNWUwIiwiZiI6IjQ3OTEyNzc3LWU4YWQtNDQ5Mi04MjI5LTBkYzJiODcyN2UxNSIsImUiOjE3ODU4MDM0OTJ9.umZ_ftxTbkem1smq1f6ryj-fjo6jdPom-KaQuiDxj-s -->
