### PR TITLE
Upgrade to Scarb 2.19.3 and Starknet Foundry 0.62.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,10 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Setup Starknet Foundry
+        uses: foundry-rs/setup-snfoundry@v3
 
       - name: Setup Scarb
         uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-lock: ./Scarb.lock
 
       - name: Test the code
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Scarb
 #######
 
 target
+.snfoundry_cache
 
 node_modules/
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-scarb 2.12.0
+scarb 2.19.3
+starknet-foundry 0.62.1

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -4,3 +4,21 @@ version = 1
 [[package]]
 name = "governance"
 version = "0.1.0"
+dependencies = [
+ "snforge_std",
+]
+
+[[package]]
+name = "snforge_scarb_plugin"
+version = "0.62.1"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:f029f266be8fd2e66339be3e39e1cdada308d49cc12c2f76f3f5e949668361da"
+
+[[package]]
+name = "snforge_std"
+version = "0.62.1"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:20ef99a8f3d6515ec609499334f9b2fe86ddf9264b84156ff068f40b28994bc8"
+dependencies = [
+ "snforge_scarb_plugin",
+]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -3,11 +3,11 @@ name = "governance"
 version = "0.1.0"
 description = "Contracts for governance of Starknet-native protocols"
 homepage = "https://ekubo.org"
-cairo-version = ">=2.12.0"
+cairo-version = ">=2.19.3"
 edition = '2024_07'
 
 [dependencies]
-starknet = ">=2.12.0"
+starknet = ">=2.19.3"
 
 [[target.starknet-contract]]
 allowed-libfuncs-list.name = "audited"
@@ -17,4 +17,8 @@ casm = true
 sort-module-level-items = true
 
 [dev-dependencies]
-cairo_test = ">=2.12.0"
+cairo_test = ">=2.19.3"
+snforge_std = ">=0.62.1"
+
+[scripts]
+test = "snforge test"

--- a/declare-all.sh
+++ b/declare-all.sh
@@ -2,7 +2,7 @@
 
 # Function to print usage and exit
 print_usage_and_exit() {
-    echo "Usage: $0 --network {sepolia,goerli-1,mainnet}"
+    echo "Usage: $0 --network {sepolia,mainnet}"
     exit 1
 }
 
@@ -27,7 +27,7 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 # Ensure network is valid
-if [ "$NETWORK" != "sepolia" -a "$NETWORK" != "mainnet" -a "$NETWORK" != "goerli-1" ]; then
+if [ "$NETWORK" != "sepolia" -a "$NETWORK" != "mainnet" ]; then
     echo "Invalid network: $NETWORK"
     print_usage_and_exit
 fi
@@ -36,22 +36,15 @@ fi
 scarb build
 
 declare_class_hash() {
-    local class_name=$1
-    starkli declare --watch --network "$NETWORK" --keystore-password "$STARKNET_KEYSTORE_PASSWORD" --casm-file  "target/dev/governance_${class_name}.compiled_contract_class.json" "target/dev/governance_${class_name}.contract_class.json"
+    # Expects an sncast account named after the network.
+    sncast --account "$NETWORK" --wait declare --network "$NETWORK" --contract-name "$1"
 }
 
 echo "Declaring AirdropClaimCheck"
-AIRDROP_CLAIM_CHECK_CLASS_HASH=$(declare_class_hash AirdropClaimCheck)
+declare_class_hash AirdropClaimCheck
 echo "Declaring Airdrop"
-AIRDROP_CLASS_HASH=$(declare_class_hash Airdrop)
+declare_class_hash Airdrop
 echo "Declaring Staker"
-STAKER_CLASS_HASH=$(declare_class_hash Staker)
+declare_class_hash governance::staker::Staker
 echo "Declaring Governor"
-GOVERNOR_CLASS_HASH=$(declare_class_hash Governor)
-
-echo "AirdropClaimCheck @ $AIRDROP_CLAIM_CHECK_CLASS_HASH"
-echo "Airdrop @ $AIRDROP_CLASS_HASH"
-echo "Staker @ $STAKER_CLASS_HASH"
-echo "Governor @ $GOVERNOR_CLASS_HASH"
-
-# starkli deploy --max-fee 0.001 --watch --network "$NETWORK" --keystore-password "$STARKNET_KEYSTORE_PASSWORD" "$AIRDROP_CLAIM_CHECK_CLASS_HASH"
+declare_class_hash Governor

--- a/src/airdrop_test.cairo
+++ b/src/airdrop_test.cairo
@@ -4,9 +4,12 @@ use governance::airdrop::Airdrop::{
 };
 use governance::airdrop::{Airdrop, Claim, Config, IAirdropDispatcher, IAirdropDispatcherTrait};
 use governance::interfaces::erc20::IERC20DispatcherTrait;
+use governance::test::helpers::{EventLoggerTrait, event_logger};
 use governance::test::test_token::{TestToken, deploy as deploy_token};
-use starknet::syscalls::deploy_syscall;
-use starknet::testing::{pop_log, set_block_timestamp};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare,
+    start_cheat_block_timestamp_global as set_block_timestamp,
+};
 use starknet::{ContractAddress, get_contract_address};
 
 fn deploy_with_refundee(
@@ -17,10 +20,8 @@ fn deploy_with_refundee(
         @(token, Config { root, refundable_timestamp, refund_to }), ref constructor_args,
     );
 
-    let (address, _) = deploy_syscall(
-        Airdrop::TEST_CLASS_HASH.try_into().unwrap(), 0, constructor_args.span(), true,
-    )
-        .expect('DEPLOY_AD_FAILED');
+    let contract = declare("Airdrop").unwrap().contract_class();
+    let (address, _) = contract.deploy(@constructor_args).expect('DEPLOY_AD_FAILED');
     IAirdropDispatcher { contract_address: address }
 }
 
@@ -83,6 +84,8 @@ fn test_compute_pedersen_root_recursive() {
 
 #[test]
 fn test_claim_single_recipient() {
+    let mut airdrop_logger = event_logger();
+    let mut token_logger = event_logger();
     let token = deploy_token(get_contract_address(), 1234567);
 
     let claim = Claim { id: 0, claimee: 2345.try_into().unwrap(), amount: 6789 };
@@ -95,12 +98,12 @@ fn test_claim_single_recipient() {
 
     assert_eq!(airdrop.claim(claim, array![].span()), true);
 
-    let log = pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
+    let log = airdrop_logger.pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
     assert_eq!(log.claim, claim);
 
-    pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
-    pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
-    let log = pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    let log = token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
     assert_eq!(log.from, airdrop.contract_address);
     assert_eq!(log.to, claim.claimee);
     assert_eq!(log.value, claim.amount.into());
@@ -108,6 +111,8 @@ fn test_claim_single_recipient() {
 
 #[test]
 fn test_claim_128_single_recipient_tree() {
+    let mut airdrop_logger = event_logger();
+    let mut token_logger = event_logger();
     let token = deploy_token(get_contract_address(), 1234567);
 
     let claim = Claim { id: 0, claimee: 2345.try_into().unwrap(), amount: 6789 };
@@ -120,12 +125,12 @@ fn test_claim_128_single_recipient_tree() {
 
     assert_eq!(airdrop.claim_128(array![claim].span(), array![].span()), 1);
 
-    let log = pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
+    let log = airdrop_logger.pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
     assert_eq!(log.claim, claim);
 
-    pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
-    pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
-    let log = pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    let log = token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
     assert_eq!(log.from, airdrop.contract_address);
     assert_eq!(log.to, claim.claimee);
     assert_eq!(log.value, claim.amount.into());
@@ -290,6 +295,8 @@ fn test_claim_two_claims() {
 
 #[test]
 fn test_claim_two_claims_via_claim_128() {
+    let mut airdrop_logger = event_logger();
+    let mut token_logger = event_logger();
     let token = deploy_token(get_contract_address(), 1234567);
 
     let claim_a = Claim { id: 0, claimee: 2345.try_into().unwrap(), amount: 6789 };
@@ -305,22 +312,26 @@ fn test_claim_two_claims_via_claim_128() {
 
     assert_eq!(airdrop.claim_128(array![claim_a, claim_b].span(), array![].span()), 2);
 
-    let claim_a_log = pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
+    let claim_a_log = airdrop_logger.pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
     assert_eq!(claim_a_log.claim, claim_a);
-    let claim_b_log = pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
+    let claim_b_log = airdrop_logger.pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
     assert_eq!(claim_b_log.claim, claim_b);
 
     // pops the initial supply transfer from 0 log
-    pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
     // pops the transfer from deployer to airdrop
-    pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
 
-    let transfer_claim_a_log = pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    let transfer_claim_a_log = token_logger
+        .pop_log::<TestToken::Transfer>(token.contract_address)
+        .unwrap();
     assert_eq!(transfer_claim_a_log.from, airdrop.contract_address);
     assert_eq!(transfer_claim_a_log.to, claim_a.claimee);
     assert_eq!(transfer_claim_a_log.value, claim_a.amount.into());
 
-    let transfer_claim_b_log = pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    let transfer_claim_b_log = token_logger
+        .pop_log::<TestToken::Transfer>(token.contract_address)
+        .unwrap();
     assert_eq!(transfer_claim_b_log.from, airdrop.contract_address);
     assert_eq!(transfer_claim_b_log.to, claim_b.claimee);
     assert_eq!(transfer_claim_b_log.value, claim_b.amount.into());
@@ -349,6 +360,8 @@ fn test_claim_three_claims_one_invalid_via_claim_128() {
 }
 
 fn test_claim_is_valid(root: felt252, claim: Claim, proof: Array<felt252>) {
+    let mut airdrop_logger = event_logger();
+    let mut token_logger = event_logger();
     let pspan = proof.span();
     let token = deploy_token(get_contract_address(), claim.amount.into());
     let airdrop = deploy(token.contract_address, root);
@@ -357,14 +370,14 @@ fn test_claim_is_valid(root: felt252, claim: Claim, proof: Array<felt252>) {
     assert_eq!(airdrop.claim(claim, pspan), true);
     assert_eq!(airdrop.claim(claim, pspan), false);
 
-    let claim_log = pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
+    let claim_log = airdrop_logger.pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
     assert_eq!(claim_log.claim, claim);
 
     // pops the initial supply transfer from 0 log
-    pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
     // pops the transfer from deployer to airdrop
-    pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
-    let transfer_log = pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+    let transfer_log = token_logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
     assert_eq!(transfer_log.from, airdrop.contract_address);
     assert_eq!(transfer_log.to, claim.claimee);
     assert_eq!(transfer_log.value, claim.amount.into());
@@ -625,6 +638,7 @@ fn test_claim_before_funded() {
 
 #[test]
 fn test_multiple_claims_from_generated_tree() {
+    let mut logger = event_logger();
     let claim_0 = Claim {
         id: 0,
         claimee: 1257981684727298919953780547925609938727371268283996697135018561811391002099
@@ -668,7 +682,7 @@ fn test_multiple_claims_from_generated_tree() {
                 .span(),
         );
 
-    let log = pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
+    let log = logger.pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
     assert_eq!(log.claim, claim_1);
 
     airdrop
@@ -690,7 +704,7 @@ fn test_multiple_claims_from_generated_tree() {
             ]
                 .span(),
         );
-    let log = pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
+    let log = logger.pop_log::<Airdrop::Claimed>(airdrop.contract_address).unwrap();
     assert_eq!(log.claim, claim_0);
 }
 
@@ -769,6 +783,7 @@ fn test_claim_128_large_tree() {
 
 #[test]
 fn test_claim_128_double_claim() {
+    let mut logger = event_logger();
     let mut i: u64 = 0;
 
     let mut claims: Array<Claim> = array![];
@@ -792,13 +807,13 @@ fn test_claim_128_double_claim() {
 
     assert_eq!(airdrop.claim_128(claims.span().slice(0, 128), array![s2, rr].span()), 128);
     let mut i: u64 = 0;
-    while let Option::Some(claimed) = pop_log::<Airdrop::Claimed>(airdrop.contract_address) {
+    while let Option::Some(claimed) = logger.pop_log::<Airdrop::Claimed>(airdrop.contract_address) {
         assert_eq!(claimed.claim, Claim { id: i, amount: 3, claimee: 0xcdee.try_into().unwrap() });
         i += 1;
     }
 
     assert_eq!(airdrop.claim_128(claims.span().slice(0, 128), array![s2, rr].span()), 0);
-    assert_eq!(pop_log::<Airdrop::Claimed>(airdrop.contract_address).is_none(), true);
+    assert_eq!(logger.pop_log::<Airdrop::Claimed>(airdrop.contract_address).is_none(), true);
 }
 
 mod refundable {

--- a/src/call_trait_test.cairo
+++ b/src/call_trait_test.cairo
@@ -62,7 +62,7 @@ fn test_hash_address_data_one_two() {
 }
 
 #[test]
-#[should_panic(expected: ('CONTRACT_NOT_DEPLOYED', 'ENTRYPOINT_FAILED'))]
+#[should_panic]
 fn test_execute_contract_not_deployed() {
     let call = Call { to: 0.try_into().unwrap(), selector: 0, calldata: array![].span() };
     call.execute();
@@ -123,4 +123,3 @@ fn test_hash_no_collision_span_length() {
 
     assert_ne!(hash_a, hash_b);
 }
-

--- a/src/governor_test.cairo
+++ b/src/governor_test.cairo
@@ -7,9 +7,14 @@ use governance::governor::{
 use governance::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
 use governance::staker::{IStakerDispatcher, IStakerDispatcherTrait};
 use governance::staker_test::setup as setup_staker;
+use governance::test::helpers::{EventLoggerTrait, event_logger};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare,
+    start_cheat_block_timestamp_global as set_block_timestamp, start_cheat_caller_address,
+    start_cheat_caller_address_global, start_cheat_transaction_version_global as set_version,
+    stop_cheat_caller_address, stop_cheat_caller_address_global,
+};
 use starknet::account::{AccountContractDispatcher, AccountContractDispatcherTrait, Call};
-use starknet::syscalls::deploy_syscall;
-use starknet::testing::{pop_log, set_block_timestamp, set_contract_address, set_version};
 use starknet::{ContractAddress, get_block_timestamp, get_contract_address};
 
 fn recipient() -> ContractAddress {
@@ -36,6 +41,13 @@ fn anyone() -> ContractAddress {
     'anyone'.try_into().unwrap()
 }
 
+fn set_contract_address(address: ContractAddress) {
+    stop_cheat_caller_address_global();
+    if address != get_contract_address() {
+        start_cheat_caller_address_global(address);
+    }
+}
+
 fn advance_time(by: u64) -> u64 {
     let next = get_block_timestamp() + by;
     set_block_timestamp(next);
@@ -59,10 +71,8 @@ fn deploy(staker: IStakerDispatcher, config: Config) -> IGovernorDispatcher {
     let mut constructor_args: Array<felt252> = array![];
     Serde::serialize(@(staker, config), ref constructor_args);
 
-    let (address, _) = deploy_syscall(
-        Governor::TEST_CLASS_HASH.try_into().unwrap(), 0, constructor_args.span(), true,
-    )
-        .expect('DEPLOY_GV_FAILED');
+    let contract = declare("Governor").unwrap().contract_class();
+    let (address, _) = contract.deploy(@constructor_args).expect('DEPLOY_GV_FAILED');
     return IGovernorDispatcher { contract_address: address };
 }
 
@@ -313,6 +323,7 @@ fn test_anyone_can_vote() {
 
 #[test]
 fn test_describe_proposal_successful() {
+    let mut logger = event_logger();
     let (staker, token, governor, _config) = setup();
     let id = create_proposal(governor, token, staker);
 
@@ -322,10 +333,10 @@ fn test_describe_proposal_successful() {
             id,
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
         );
-    pop_log::<Governor::Reconfigured>(governor.contract_address).unwrap();
-    pop_log::<Governor::Proposed>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Reconfigured>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Proposed>(governor.contract_address).unwrap();
     assert_eq!(
-        pop_log::<Governor::Described>(governor.contract_address).unwrap(),
+        logger.pop_log::<Governor::Described>(governor.contract_address).unwrap(),
         Governor::Described {
             id,
             description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
@@ -335,6 +346,7 @@ fn test_describe_proposal_successful() {
 
 #[test]
 fn test_propose_and_describe_successful() {
+    let mut logger = event_logger();
     let (staker, token, governor, config) = setup();
     token.approve(staker.contract_address, config.proposal_creation_threshold.into());
     staker.stake(proposer());
@@ -350,10 +362,10 @@ fn test_propose_and_describe_successful() {
         );
     set_contract_address(address_before);
 
-    pop_log::<Governor::Reconfigured>(governor.contract_address).unwrap();
-    pop_log::<Governor::Proposed>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Reconfigured>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Proposed>(governor.contract_address).unwrap();
     assert_eq!(
-        pop_log::<Governor::Described>(governor.contract_address).unwrap(),
+        logger.pop_log::<Governor::Described>(governor.contract_address).unwrap(),
         Governor::Described {
             id,
             description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
@@ -403,7 +415,7 @@ fn test_describe_proposal_fails_if_executed() {
     set_contract_address(voter1());
     governor.vote(id, true);
     advance_time(config.voting_period + config.execution_delay);
-    set_contract_address(anyone());
+    set_contract_address(get_contract_address());
     governor.execute(id, array![transfer_call(token, anyone(), amount: 0)].span());
 
     set_contract_address(proposer());
@@ -625,7 +637,7 @@ fn test_execute_valid_proposal() {
 
     advance_time(config.voting_period + config.execution_delay);
 
-    set_contract_address(anyone());
+    set_contract_address(get_contract_address());
 
     governor
         .execute(
@@ -785,35 +797,44 @@ fn test_verify_votes_are_counted_over_voting_weight_smoothing_duration_from_star
 
     token.transfer(voter1, 49);
     token.transfer(voter2, 51);
-    set_contract_address(voter1);
+    stop_cheat_caller_address(token.contract_address);
+    start_cheat_caller_address(token.contract_address, voter1);
     token.approve(staker.contract_address, 49);
+    stop_cheat_caller_address(token.contract_address);
+    start_cheat_caller_address(staker.contract_address, voter1);
     staker.stake(voter1);
-    set_contract_address(voter2);
+    stop_cheat_caller_address(staker.contract_address);
+    start_cheat_caller_address(token.contract_address, voter2);
     token.approve(staker.contract_address, 51);
+    stop_cheat_caller_address(token.contract_address);
+    start_cheat_caller_address(staker.contract_address, voter2);
     staker.stake(voter2);
+    stop_cheat_caller_address(staker.contract_address);
 
     // the full amount of delegation should be vested over 30 seconds
     advance_time(config.voting_weight_smoothing_duration);
 
+    start_cheat_caller_address(governor.contract_address, voter2);
     let id = governor
         .propose(array![transfer_call(token: token, recipient: recipient(), amount: 100)].span());
 
     advance_time(config.voting_start_delay - (config.voting_weight_smoothing_duration / 3));
     // undelegate 1/3rd of a duration before voting starts, so only a third of voting power is
     // counted for voter1
-    set_contract_address(voter1);
+    start_cheat_caller_address(staker.contract_address, voter1);
     staker.withdraw_amount(voter1, recipient: Zero::zero(), amount: 49);
+    stop_cheat_caller_address(staker.contract_address);
 
     advance_time((config.voting_weight_smoothing_duration / 3));
 
     // vote less than quorum because of smoothing duration
-    set_contract_address(voter1);
+    start_cheat_caller_address(governor.contract_address, voter1);
     governor.vote(id, true);
     let proposal = governor.get_proposal(id);
     assert_eq!(proposal.yea, 32);
     assert_eq!(proposal.nay, 0);
 
-    set_contract_address(voter2);
+    start_cheat_caller_address(governor.contract_address, voter2);
     governor.vote(id, false);
     let proposal = governor.get_proposal(id);
     assert_eq!(proposal.yea, 32);
@@ -822,6 +843,7 @@ fn test_verify_votes_are_counted_over_voting_weight_smoothing_duration_from_star
     advance_time(config.voting_period + config.execution_delay);
 
     // Execute the proposal. If the quorum was not met, this should fail.
+    set_contract_address(get_contract_address());
     governor
         .execute(
             id, array![transfer_call(token: token, recipient: recipient(), amount: 100)].span(),
@@ -887,11 +909,13 @@ fn test_quorum_counts_only_yes_votes_exactly_met() {
 
     advance_time(config.voting_period + config.execution_delay);
 
+    set_contract_address(get_contract_address());
     governor.execute(id, calls);
 }
 
 #[test]
 fn test_execute_emits_logs_from_data() {
+    let mut logger = event_logger();
     let (staker, token, governor, config) = setup();
     let calls = array![
         transfer_call(token: token, recipient: recipient(), amount: 150),
@@ -919,17 +943,18 @@ fn test_execute_emits_logs_from_data() {
 
     advance_time(config.voting_period + config.execution_delay);
 
+    set_contract_address(get_contract_address());
     let result = governor.execute(id, calls);
     let expected = array![array![1_felt252].span(), array![1].span()].span();
     // both transfers suceeded
     assert_eq!(result, expected);
 
-    pop_log::<Governor::Reconfigured>(governor.contract_address).unwrap();
-    pop_log::<Governor::Proposed>(governor.contract_address).unwrap();
-    pop_log::<Governor::Voted>(governor.contract_address).unwrap();
-    pop_log::<Governor::Voted>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Reconfigured>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Proposed>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Voted>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Voted>(governor.contract_address).unwrap();
     // and the governor emitted it too
-    let executed = pop_log::<Governor::Executed>(governor.contract_address).unwrap();
+    let executed = logger.pop_log::<Governor::Executed>(governor.contract_address).unwrap();
     assert_eq!(executed, Governor::Executed { id, result_data: expected });
 }
 
@@ -949,7 +974,7 @@ fn test_execute_already_executed_should_fail() {
     governor.vote(id, true); // vote so that proposal reaches quorum
     advance_time(config.voting_period + config.execution_delay);
 
-    set_contract_address(anyone());
+    set_contract_address(get_contract_address());
     governor
         .execute(
             id, array![transfer_call(token: token, recipient: recipient(), amount: 100)].span(),
@@ -993,6 +1018,7 @@ fn test_upgrade_fails_if_not_self_call() {
 #[test]
 fn test_upgrade_succeeds_self_call() {
     let (staker, token, governor, config) = setup();
+    let governor_class_hash = *declare("Governor").unwrap().contract_class().class_hash;
 
     token.approve(staker.contract_address, config.quorum.into());
     staker.stake(proposer());
@@ -1005,7 +1031,7 @@ fn test_upgrade_succeeds_self_call() {
         Call {
             to: governor.contract_address,
             selector: selector!("upgrade"),
-            calldata: array![Governor::TEST_CLASS_HASH.into()].span(),
+            calldata: array![governor_class_hash.into()].span(),
         },
     );
 
@@ -1016,6 +1042,7 @@ fn test_upgrade_succeeds_self_call() {
 
     advance_time(config.voting_period + config.execution_delay);
 
+    set_contract_address(get_contract_address());
     governor
         .execute(
             id,
@@ -1023,7 +1050,7 @@ fn test_upgrade_succeeds_self_call() {
                 Call {
                     to: governor.contract_address,
                     selector: selector!("upgrade"),
-                    calldata: array![Governor::TEST_CLASS_HASH.into()].span(),
+                    calldata: array![governor_class_hash.into()].span(),
                 },
             ]
                 .span(),
@@ -1064,6 +1091,7 @@ fn test_send_message_to_l1_succeeds_self_call() {
 
     advance_time(config.voting_period + config.execution_delay);
 
+    set_contract_address(get_contract_address());
     governor
         .execute(
             id,
@@ -1125,6 +1153,7 @@ fn test_governor_execute_fails_from_non_zero() {
 #[should_panic(expected: ('Invalid TX version', 'ENTRYPOINT_FAILED'))]
 fn test_governor_execute_fails_tx_version_0() {
     let (_staker, _token, governor, _config) = setup();
+    start_cheat_caller_address(governor.contract_address, Zero::zero());
     set_version(0);
     AccountContractDispatcher { contract_address: governor.contract_address }.__execute__(array![]);
 }
@@ -1133,6 +1162,7 @@ fn test_governor_execute_fails_tx_version_0() {
 #[should_panic(expected: ('Invalid TX version', 'ENTRYPOINT_FAILED'))]
 fn test_governor_execute_fails_tx_version_1() {
     let (_staker, _token, governor, _config) = setup();
+    start_cheat_caller_address(governor.contract_address, Zero::zero());
     set_version(1);
     AccountContractDispatcher { contract_address: governor.contract_address }.__execute__(array![]);
 }
@@ -1140,12 +1170,14 @@ fn test_governor_execute_fails_tx_version_1() {
 #[test]
 fn test_governor_execute_succeeds_version_simulate() {
     let (_staker, _token, governor, _config) = setup();
+    start_cheat_caller_address(governor.contract_address, Zero::zero());
     set_version(0x100000000000000000000000000000001);
     AccountContractDispatcher { contract_address: governor.contract_address }.__execute__(array![]);
 }
 
 #[test]
 fn test_reconfigure_succeeds_self_call() {
+    let mut logger = event_logger();
     let (staker, token, governor, config) = setup();
 
     token.approve(staker.contract_address, config.quorum.into());
@@ -1182,6 +1214,7 @@ fn test_reconfigure_succeeds_self_call() {
 
     advance_time(config.voting_period + config.execution_delay);
 
+    set_contract_address(get_contract_address());
     governor
         .execute(
             id,
@@ -1196,13 +1229,13 @@ fn test_reconfigure_succeeds_self_call() {
         );
 
     // the first one is from constructor
-    pop_log::<Governor::Reconfigured>(governor.contract_address).unwrap();
-    pop_log::<Governor::Proposed>(governor.contract_address).unwrap();
-    pop_log::<Governor::Voted>(governor.contract_address).unwrap();
-    let reconfigured = pop_log::<Governor::Reconfigured>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Reconfigured>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Proposed>(governor.contract_address).unwrap();
+    logger.pop_log::<Governor::Voted>(governor.contract_address).unwrap();
+    let reconfigured = logger.pop_log::<Governor::Reconfigured>(governor.contract_address).unwrap();
     assert_eq!(reconfigured.new_config, new_config);
     assert_eq!(reconfigured.version, 1);
-    let executed = pop_log::<Governor::Executed>(governor.contract_address).unwrap();
+    let executed = logger.pop_log::<Governor::Executed>(governor.contract_address).unwrap();
     assert_eq!(governor.get_config_with_version(), (new_config, 1));
     assert_eq!(executed.id, id);
     assert_eq!(executed.result_data, array![array![1_felt252].span()].span());
@@ -1210,6 +1243,7 @@ fn test_reconfigure_succeeds_self_call() {
     let (_, first_proposal_config) = governor.get_proposal_with_config(id);
     assert_eq!(first_proposal_config, config);
 
+    set_contract_address(proposer());
     let id_next = governor.propose(array![].span());
     let (_, next_proposal_config) = governor.get_proposal_with_config(id_next);
     assert_eq!(next_proposal_config, new_config);

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -36,6 +36,6 @@ mod utils {
 
 #[cfg(test)]
 mod test {
+    pub(crate) mod helpers;
     pub(crate) mod test_token;
 }
-

--- a/src/staker_test.cairo
+++ b/src/staker_test.cairo
@@ -3,31 +3,32 @@ use governance::execution_state_test::assert_pack_unpack;
 use governance::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
 use governance::staker::Staker::{DelegatedSnapshot, DelegatedSnapshotStorePacking};
 use governance::staker::{IStakerDispatcher, IStakerDispatcherTrait, Staker};
+use governance::test::helpers::{EventLoggerTrait, event_logger};
 use governance::test::test_token::{TestToken, deploy as deploy_token};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare,
+    start_cheat_block_timestamp_global as set_block_timestamp,
+};
 use starknet::get_contract_address;
-use starknet::syscalls::deploy_syscall;
-use starknet::testing::{pop_log, set_block_timestamp};
 
 pub(crate) fn setup(amount: u256) -> (IStakerDispatcher, IERC20Dispatcher) {
     let token = deploy_token(get_contract_address(), amount);
-    let (staker_address, _) = deploy_syscall(
-        Staker::TEST_CLASS_HASH.try_into().unwrap(),
-        0,
-        array![token.contract_address.into()].span(),
-        true,
-    )
+    let contract = declare("governance::staker::Staker").unwrap().contract_class();
+    let (staker_address, _) = contract
+        .deploy(@array![token.contract_address.into()])
         .expect('DEPLOY_TK_FAILED');
     return (IStakerDispatcher { contract_address: staker_address }, token);
 }
 
 mod stake_withdraw {
     use super::{
-        IERC20DispatcherTrait, IStakerDispatcherTrait, Staker, TestToken, Zero,
-        get_contract_address, pop_log, setup,
+        EventLoggerTrait, IERC20DispatcherTrait, IStakerDispatcherTrait, Staker, TestToken, Zero,
+        event_logger, get_contract_address, setup,
     };
 
     #[test]
     fn test_takes_approved_token() {
+        let mut logger = event_logger();
         let (staker, token) = setup(1000);
 
         token.approve(staker.contract_address, 500);
@@ -37,9 +38,9 @@ mod stake_withdraw {
         assert_eq!(staker.get_staked(get_contract_address(), Zero::zero()), 0);
         assert_eq!(staker.get_staked('delegate'.try_into().unwrap(), get_contract_address()), 0);
         // pop the transfer from 0 to deployer
-        pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+        logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
         assert_eq!(
-            pop_log::<TestToken::Transfer>(token.contract_address),
+            logger.pop_log::<TestToken::Transfer>(token.contract_address),
             Option::Some(
                 TestToken::Transfer {
                     from: get_contract_address(), to: staker.contract_address, value: 500,
@@ -47,7 +48,7 @@ mod stake_withdraw {
             ),
         );
         assert_eq!(
-            pop_log::<Staker::Staked>(staker.contract_address),
+            logger.pop_log::<Staker::Staked>(staker.contract_address),
             Option::Some(
                 Staker::Staked {
                     from: get_contract_address(),

--- a/src/staker_v2_test.cairo
+++ b/src/staker_v2_test.cairo
@@ -3,31 +3,32 @@ use governance::execution_state_test::assert_pack_unpack;
 use governance::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
 use governance::staker_v2::Staker::{DelegatedSnapshot, DelegatedSnapshotStorePacking};
 use governance::staker_v2::{IStakerV2Dispatcher, IStakerV2DispatcherTrait, Staker};
+use governance::test::helpers::{EventLoggerTrait, event_logger};
 use governance::test::test_token::{TestToken, deploy as deploy_token};
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare,
+    start_cheat_block_timestamp_global as set_block_timestamp,
+};
 use starknet::get_contract_address;
-use starknet::syscalls::deploy_syscall;
-use starknet::testing::{pop_log, set_block_timestamp};
 
 pub(crate) fn setup(amount: u256) -> (IStakerV2Dispatcher, IERC20Dispatcher) {
     let token = deploy_token(get_contract_address(), amount);
-    let (staker_address, _) = deploy_syscall(
-        Staker::TEST_CLASS_HASH.try_into().unwrap(),
-        0,
-        array![token.contract_address.into()].span(),
-        true,
-    )
+    let contract = declare("governance::staker_v2::Staker").unwrap().contract_class();
+    let (staker_address, _) = contract
+        .deploy(@array![token.contract_address.into()])
         .expect('DEPLOY_TK_FAILED');
     return (IStakerV2Dispatcher { contract_address: staker_address }, token);
 }
 
 mod stake_withdraw {
     use super::{
-        IERC20DispatcherTrait, IStakerV2DispatcherTrait, Staker, TestToken, Zero,
-        get_contract_address, pop_log, setup,
+        EventLoggerTrait, IERC20DispatcherTrait, IStakerV2DispatcherTrait, Staker, TestToken, Zero,
+        event_logger, get_contract_address, setup,
     };
 
     #[test]
     fn test_takes_approved_token() {
+        let mut logger = event_logger();
         let (staker, token) = setup(1000);
 
         token.approve(staker.contract_address, 500);
@@ -37,9 +38,9 @@ mod stake_withdraw {
         assert_eq!(staker.get_staked(get_contract_address(), Zero::zero()), 0);
         assert_eq!(staker.get_staked('delegate'.try_into().unwrap(), get_contract_address()), 0);
         // pop the transfer from 0 to deployer
-        pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
+        logger.pop_log::<TestToken::Transfer>(token.contract_address).unwrap();
         assert_eq!(
-            pop_log::<TestToken::Transfer>(token.contract_address),
+            logger.pop_log::<TestToken::Transfer>(token.contract_address),
             Option::Some(
                 TestToken::Transfer {
                     from: get_contract_address(), to: staker.contract_address, value: 500,
@@ -47,7 +48,7 @@ mod stake_withdraw {
             ),
         );
         assert_eq!(
-            pop_log::<Staker::Staked>(staker.contract_address),
+            logger.pop_log::<Staker::Staked>(staker.contract_address),
             Option::Some(
                 Staker::Staked {
                     from: get_contract_address(),

--- a/src/test/helpers.cairo
+++ b/src/test/helpers.cairo
@@ -1,0 +1,37 @@
+use snforge_std::{EventSpy, EventSpyTrait, spy_events};
+use starknet::ContractAddress;
+
+#[derive(Drop)]
+pub(crate) struct EventLogger {
+    spy: EventSpy,
+    index: usize,
+}
+
+pub(crate) fn event_logger() -> EventLogger {
+    EventLogger { spy: spy_events(), index: 0 }
+}
+
+#[generate_trait]
+pub(crate) impl EventLoggerImpl of EventLoggerTrait {
+    fn pop_log<T, +starknet::Event<T>, +Drop<T>>(
+        ref self: EventLogger, address: ContractAddress,
+    ) -> Option<T> {
+        let events = self.spy.get_events().events;
+        loop {
+            if self.index >= events.len() {
+                break Option::None;
+            }
+
+            let (from, event) = events.at(self.index);
+            self.index += 1;
+            if *from == address {
+                let mut keys = event.keys.span();
+                let mut data = event.data.span();
+                match starknet::Event::deserialize(ref keys, ref data) {
+                    Option::Some(value) => { break Option::Some(value); },
+                    Option::None => { continue; },
+                }
+            }
+        }
+    }
+}

--- a/src/test/test_token.cairo
+++ b/src/test/test_token.cairo
@@ -1,10 +1,11 @@
-use governance::interfaces::erc20::{IERC20Dispatcher};
-use starknet::{ContractAddress, syscalls::{deploy_syscall}};
+use governance::interfaces::erc20::IERC20Dispatcher;
+use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+use starknet::ContractAddress;
 
 #[starknet::contract]
 pub(crate) mod TestToken {
-    use core::num::traits::zero::{Zero};
-    use governance::interfaces::erc20::{IERC20};
+    use core::num::traits::zero::Zero;
+    use governance::interfaces::erc20::IERC20;
     use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
     use starknet::{ContractAddress, get_caller_address};
 
@@ -83,9 +84,7 @@ pub(crate) fn deploy(owner: ContractAddress, amount: u256) -> IERC20Dispatcher {
     let mut constructor_args: Array<felt252> = ArrayTrait::new();
     Serde::serialize(@(owner, amount), ref constructor_args);
 
-    let (address, _) = deploy_syscall(
-        TestToken::TEST_CLASS_HASH.try_into().unwrap(), 0, constructor_args.span(), true,
-    )
-        .expect('DEPLOY_TOKEN_FAILED');
+    let contract = declare("TestToken").unwrap().contract_class();
+    let (address, _) = contract.deploy(@constructor_args).expect('DEPLOY_TOKEN_FAILED');
     IERC20Dispatcher { contract_address: address }
 }


### PR DESCRIPTION
## Summary

- upgrade Scarb and Cairo to 2.19.3 and pin Starknet Foundry 0.62.1 in `.tool-versions`
- run Cairo tests through `snforge test`, including Foundry-native class declaration, cheatcodes, and event spies
- install Starknet Foundry in CI and resolve versions from `Scarb.lock`
- migrate `declare-all.sh` from `starkli` to `sncast`, remove `goerli-1`, and disambiguate the legacy Staker contract path

## Validation

- `scarb build`
- `scarb test` (157 passed)
- `bash -n declare-all.sh`
