### PR TITLE
Require strict majority for governor proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Contracts in this repository are designed so that they may be used together _or_
 - A delegate may create a proposal to make a batch of `calls` if their voting weight exceeds the proposal creation threshold
 - After the `voting_start_delay`, users may choose to vote `yea` or `nay` on the created proposal for the duration of the `voting_period`
   - A voter's voting weight is computed based on their average delegation over the period `voting_weight_smoothing_duration` from before the start time of the proposal
-- If a proposal receives at least `quorum` in voting weight, and the simple majority of total votes is `yea`, and the voting period is over, the proposal may be executed exactly once
+- If a proposal receives at least `quorum` in `yea` voting weight, has a strict majority (`yea > nay`), and the voting period is over, it may be executed exactly once; tied votes fail
   - Must happen after the voting has ended and the execution delay has passed
   - If any of the calls fails, the transaction will revert, and anyone may attempt to execute the proposal again, up until the end of the execution window
 - Proposals can be canceled at any time by _anyone_ iff the voting weight of the proposer falls below the proposal creation threshold, up until it is executed

--- a/src/governor.cairo
+++ b/src/governor.cairo
@@ -28,7 +28,7 @@ pub struct Config {
     // Over how many seconds the voting weight is averaged for proposal voting as well as
     // creation/cancellation
     pub voting_weight_smoothing_duration: u64,
-    // How many total votes must be collected for the proposal
+    // How much yea voting weight must be collected for the proposal
     pub quorum: u128,
     // The minimum amount of average votes required to create a proposal
     pub proposal_creation_threshold: u128,

--- a/src/governor.cairo
+++ b/src/governor.cairo
@@ -386,7 +386,7 @@ pub mod Governor {
             assert(timestamp_current < window_end, 'EXECUTION_WINDOW_OVER');
 
             assert(proposal.yea >= config.quorum, 'QUORUM_NOT_MET');
-            assert(proposal.yea >= proposal.nay, 'NO_MAJORITY');
+            assert(proposal.yea > proposal.nay, 'NO_MAJORITY');
 
             proposal
                 .execution_state =

--- a/src/governor_test.cairo
+++ b/src/governor_test.cairo
@@ -739,6 +739,41 @@ fn test_execute_no_majority_should_fail() {
 }
 
 #[test]
+#[should_panic(expected: ('NO_MAJORITY', 'ENTRYPOINT_FAILED'))]
+fn test_execute_tied_vote_should_fail() {
+    let (staker, token, governor, config) = setup();
+
+    token.approve(staker.contract_address, config.quorum.into());
+    staker.stake(voter1());
+    token.approve(staker.contract_address, config.quorum.into());
+    staker.stake(voter2());
+
+    advance_time(config.voting_weight_smoothing_duration);
+
+    set_contract_address(voter2());
+    let id = governor
+        .propose(array![transfer_call(token: token, recipient: recipient(), amount: 100)].span());
+
+    advance_time(config.voting_start_delay);
+
+    set_contract_address(voter1());
+    governor.vote(id, true);
+    set_contract_address(voter2());
+    governor.vote(id, false);
+
+    let proposal = governor.get_proposal(id);
+    assert_eq!(proposal.yea, config.quorum);
+    assert_eq!(proposal.nay, config.quorum);
+
+    advance_time(config.voting_period + config.execution_delay);
+
+    governor
+        .execute(
+            id, array![transfer_call(token: token, recipient: recipient(), amount: 100)].span(),
+        );
+}
+
+#[test]
 #[should_panic(expected: ('EXECUTION_WINDOW_NOT_STARTED', 'ENTRYPOINT_FAILED'))]
 fn test_execute_before_execution_window_begins() {
     let (staker, token, governor, config) = setup();


### PR DESCRIPTION
## Summary
- require yea voting weight to be strictly greater than nay voting weight before execution
- add regression coverage proving tied votes cannot execute
- clarify the strict-majority and quorum behavior in the Governor documentation

## Testing
- `scarb test` (158 passed)
- `scarb fmt --check src/governor.cairo`
- `scarb fmt --check src/governor_test.cairo`

The repository-wide formatter check still reports pre-existing formatting drift in unrelated files.